### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-*.bas linguist-language=VBA
-*.cls linguist-language=VBA
+*.bas linguist-language=VBA working-tree-encoding=CP1252
+*.cls linguist-language=VBA working-tree-encoding=CP1252
 *.bas eol=crlf


### PR DESCRIPTION
Add working-tree-encoding to tell GitHub to perform the conversion from UTF-8 to CP1252 when cloning or downloading the repo as a .zip file.

This will make sure non-ascii characters don't get turned into �.